### PR TITLE
Add fluency to links helper add method

### DIFF
--- a/src/Aura/View/Helper/Links.php
+++ b/src/Aura/View/Helper/Links.php
@@ -46,12 +46,13 @@ class Links extends AbstractHelper
      * 
      * @param array $attribs Attributes for the <link> tag.
      * 
-     * @return void
+     * @return $this
      * 
      */
     public function add($attribs = [])
     {
         $this->links[] = $this->void('link', $attribs);
+        return $this;
     }
 
     /**

--- a/tests/Aura/View/Helper/LinksTest.php
+++ b/tests/Aura/View/Helper/LinksTest.php
@@ -37,6 +37,25 @@ class LinksTest extends AbstractHelperTest
                 . '    <link rel="next" href="/path/to/next?this&amp;that" />' . PHP_EOL;
        
         $this->assertSame($expect, $actual);
+        
+        // Now test adding links fluently
+        unset($links);
+        $links = new Links;
+        
+        $escaper = $this->escape((object) [
+            'prev' => [
+                'rel' => 'prev',
+                'href' => '/path/to/prev?this&that',
+            ],
+            'next' => [
+                'rel' => 'next',
+                'href' => '/path/to/next?this&that',
+            ]
+        ]);
+        
+        $actual = $links->add($escaper->prev)->add($escaper->next)->get();
+        
+        $this->assertSame($expect, $actual);
     }
 
     /**


### PR DESCRIPTION
Thought it might be handy to use the links helper fluently
Rather than...

``` php
$links = $this->links();
$links->add($attribs);
$links->add($otherattribs);
echo $links->get();
```

Do this

``` php
echo $this->links()
               ->add($attribs)
               ->add($otherattribs)
               ->get();
```

What do you think? Seem reasonable?
