### PR TITLE
Revert to older way of passing vars to partials

### DIFF
--- a/src/TemplateRegistry.php
+++ b/src/TemplateRegistry.php
@@ -59,9 +59,10 @@ class TemplateRegistry
     public function set($name, $spec)
     {
         if (is_string($spec)) {
-            $__file__ = $spec;
-            $spec = function () use ($__file__) {
-                require $__file__;
+            $__FILE__ = $spec;
+            $spec = function (array $__VARS__ = array()) use ($__FILE__) {
+                extract($__VARS__, EXTR_SKIP);
+                require $__FILE__;
             };
         }
         $this->map[$name] = $spec;

--- a/src/View.php
+++ b/src/View.php
@@ -47,20 +47,17 @@ class View extends AbstractView
      *
      * @param string $name The name of the template to be rendered.
      *
-     * @param array|Traversable $data Data to add to the view; note that the
-     * data is added to the view object as a whole, not just for the template
-     * being rendered.
+     * @param array $vars Variables to `extract()` within the view as local
+     * variables. Closure-based templates will need to call `extract()` on
+     * their own.
      *
      * @return string
      *
      */
-    protected function render($name, $data = null)
+    protected function render($name, array $vars = array())
     {
-        if ($data) {
-            $this->addData($data);
-        }
         ob_start();
-        $this->getTemplate($name)->__invoke();
+        $this->getTemplate($name)->__invoke($vars);
         return ob_get_clean();
     }
 }

--- a/tests/src/ViewTest.php
+++ b/tests/src/ViewTest.php
@@ -22,12 +22,13 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         $view_registry->set('master', function () {
             foreach (array('bar', 'baz', 'dib') as $foo) {
                 echo $this->render('_partial', array(
-                    '_foo' => $foo,
+                    'foo' => $foo,
                 ));
             }
         });
-        $view_registry->set('_partial', function () {
-            echo "foo = {$this->_foo}" . PHP_EOL;
+        $view_registry->set('_partial', function (array $vars) {
+            extract($vars);
+            echo "foo = {$foo}" . PHP_EOL;
         });
         $view_registry->set('sections', function () {
             $this->setSection('foo', 'foo bar baz');


### PR DESCRIPTION
Currently, render() assigns variables to $this. After continued use, that ends up being somewhat messy. This PR goes back to the older way of extract()ing variables into the partial template scope, and includes notes on how to make that work with closure-based templates.
