### PR TITLE
TemplateRegistry map should pass the array via set to make the file insi...

### DIFF
--- a/src/TemplateRegistry.php
+++ b/src/TemplateRegistry.php
@@ -37,7 +37,9 @@ class TemplateRegistry
      */
     public function __construct(array $map = array())
     {
-        $this->map = $map;
+        foreach ($map as $name => $spec) {
+            $this->set($name, $spec);
+        }
     }
 
     /**

--- a/tests/unit/src/ViewTest.php
+++ b/tests/unit/src/ViewTest.php
@@ -132,4 +132,17 @@ class ViewTest extends \PHPUnit_Framework_TestCase
         $expect = 'foo bar baz dib zim gir irk';
         $this->assertSame($expect, $actual);
     }
+
+    public function testMapFilesToTemplateRegistryOnConstruct()
+    {
+        $view = new View(
+            new TemplateRegistry(array('foo' => __DIR__ . '/foo_template.php')),
+            new TemplateRegistry,
+            new HelperRegistry
+        );
+        $view->setView('foo');
+        $actual = $view->__invoke();
+        $expect = 'Hello Foo!';
+        $this->assertSame($expect, $actual);
+    }
 }


### PR DESCRIPTION
...de a closure. Else Fatal error:  Call to a member function bindTo() on a non-object
