### PR TITLE
Add HHVM target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
 script:
   - phpunit -c tests/unit/ --coverage-clover=coverage.clover
 after_script:


### PR DESCRIPTION
As of HHVM 3.4 (specifically https://github.com/facebook/hhvm/commit/3e290683d8504c74570343aee66da45863db8adf), closure support is where it needs to be to allow all tests to pass.
