### PR TITLE
Add "Namespace" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,23 @@ $view_registry->setPaths(array(
 
 When we refer to named templates later, the registry will search from the first directory to the last. For finer control over the search paths, we can call `prependPath()` to add a directory to search earlier, or `appendPath()` to add a directory to search later. Regardless, the _View_ will auto-append `.php` to the end of template names when searching through the directories.
 
+#### Template Namespaces
+
+We can also add namespaced templates which we can refer to with the syntax `namespace::template`.
+We can add directories that coorespond to namespaces:
+
+```php
+<?php
+$view_registry = $view->getViewRegistry();
+$view_registry->appendPath('/path/to/templates', 'my-namespace');
+
+$view->setView('my-namespace::browse');
+```
+
+When we refer to namespaced templates, only the paths associated with that
+namespace will be searched.
+
+
 ### Changing The Template File Extension
 
 By default, each _TemplateRegistry_ will auto-append `.php` to template file names. If the template files end with a different extension, change it usin the `setTemplateFileExtension()` method:

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ When we refer to named templates later, the registry will search from the first 
 #### Template Namespaces
 
 We can also add namespaced templates which we can refer to with the syntax `namespace::template`.
-We can add directories that coorespond to namespaces:
+We can add directories that correspond to namespaces:
 
 ```php
 <?php
@@ -403,7 +403,7 @@ namespace will be searched.
 
 ### Changing The Template File Extension
 
-By default, each _TemplateRegistry_ will auto-append `.php` to template file names. If the template files end with a different extension, change it usin the `setTemplateFileExtension()` method:
+By default, each _TemplateRegistry_ will auto-append `.php` to template file names. If the template files end with a different extension, change it using the `setTemplateFileExtension()` method:
 
 ```php
 <?php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,9 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+      <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">./src</directory>
+      </whitelist>
+    </filter>
 </phpunit>

--- a/tests/TemplateRegistryTest.php
+++ b/tests/TemplateRegistryTest.php
@@ -115,4 +115,51 @@ class TemplateRegistryTest extends \PHPUnit_Framework_TestCase
         $actual = $this->template_registry->get('no-such-template');
     }
 
+    public function testFindNamespaced()
+    {
+        $this->template_registry = new FakeTemplateRegistry;
+        $this->template_registry->appendPath('/foo');
+        $this->template_registry->appendPath('/bar', 'ns');
+
+        $file = '/bar' . DIRECTORY_SEPARATOR . 'zim.php';
+        $this->template_registry->fakefs[$file] = 'fake';
+
+        $expect = $file;
+        $actual = $this->template_registry->get('ns::zim');
+        $this->assertSame($expect, $actual);
+
+        // prepend
+        $this->template_registry->prependPath('/bar', 'ns2');
+        $this->template_registry->prependPath('/baz', 'ns2');
+
+        $wrong = '/bar' . DIRECTORY_SEPARATOR . 'zim.php';
+        $this->template_registry->fakefs[$wrong] = 'wrong';
+
+        $file = '/baz' . DIRECTORY_SEPARATOR . 'zim.php';
+        $this->template_registry->fakefs[$file] = 'new';
+
+        $expect = $file;
+        $actual = $this->template_registry->get('ns2::zim');
+        $this->assertSame($expect, $actual);
+
+
+        // doesnt exist
+        $this->setExpectedException('Aura\View\Exception\TemplateNotFound');
+        $actual = $this->template_registry->get('ns::zam');
+    }
+
+    public function testUnregisteredNs()
+    {
+        $this->template_registry = new FakeTemplateRegistry;
+        $this->setExpectedException('Aura\View\Exception\TemplateNotFound');
+        $actual = $this->template_registry->get('ns::no-exist');
+    }
+
+    public function testBadNamespace()
+    {
+        $this->template_registry = new FakeTemplateRegistry;
+        $this->setExpectedException('InvalidArgumentException');
+        $actual = $this->template_registry->get('ns::wrong::format');
+    }
+
 }


### PR DESCRIPTION
[Zend Expressive Template Interface](https://github.com/zendframework/zend-expressive-template) defines [support for namespaces](https://docs.zendframework.com/zend-expressive/features/template/interface/#namespaces) using the `::` scope resolution operator. 

- [Plates calls this folders](http://platesphp.com/engine/folders/)
- [Twig has namespaces](https://twig.symfony.com/doc/2.x/api.html#built-in-loaders), but they have a weird `@` notation. 

Personally, I've just been using paths to basically simulate some approximation of this functionality, and had previously been considering trying to add some kind of PSR-4-like directory definition that would basically just pretend a directory structure was deeper than it was, but this seems like a solution, and seems to exist elsewhere too.

Thoughts?

(On an unrelated note, and thoughts/idea on starting 3.x anytime so we can modernize some syntax and get rid of some of the old cruft?)